### PR TITLE
fixed login error

### DIFF
--- a/arcsightrest.py
+++ b/arcsightrest.py
@@ -33,7 +33,7 @@ class ArcsightLogger(object):
                 'password': password,
             }, is_json=False)
         r.raise_for_status()
-        loginrequest = untangle.parse(r.content)
+        loginrequest = untangle.parse(r.text)
         self.token = loginrequest.ns3_loginResponse.ns3_return.cdata
 
     def _post(self, route, data, is_json=True,):


### PR DESCRIPTION
changed r.content to r.text to have a normal string instead of a bytestring.
The bytestring causes an error while logging in to the arcsight logger